### PR TITLE
Add useAfterInteractionsEffect Hook for Post-Interaction Side Effects

### DIFF
--- a/hooks/useAfterInteractionsEffect.ts
+++ b/hooks/useAfterInteractionsEffect.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { InteractionManager } from "react-native";
+
+export const useAfterInteractionsEffect = (
+  effect: () => void | (() => void),
+  deps: React.DependencyList = []
+): void => {
+  useEffect(() => {
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      effect();
+    });
+
+    return () => {
+      interaction.cancel();
+    };
+  }, deps);
+};

--- a/useShakeAnimation.ts
+++ b/useShakeAnimation.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+const useShakeAnimation = (error: string) => {
+  const shake = useSharedValue(0);
+
+  useEffect(() => {
+    if (error) {
+      shake.value = withSequence(
+        withTiming(-5, { duration: 90 }),
+        withTiming(5, { duration: 90 }),
+        withTiming(-5, { duration: 90 }),
+        withTiming(5, { duration: 90 }),
+        withTiming(0, { duration: 90 })
+      );
+    }
+  }, [error]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: shake.value }],
+  }));
+
+  return { animatedStyle };
+};
+
+export default useShakeAnimation;


### PR DESCRIPTION
#### 📌 Summary

This PR introduces a custom React hook named `useAfterInteractionsEffect`, which defers the execution of side effects until after all ongoing React Native interactions (e.g., animations, gestures) are completed. This helps prevent performance issues and ensures that heavier tasks don’t interfere with smooth UI transitions.

#### ✅ What’s Added

* `hooks/useAfterInteractionsEffect.ts`
  A reusable hook that wraps `InteractionManager.runAfterInteractions` in a `useEffect` pattern.

#### 🧠 How It Works

* Accepts a callback function (`effect`) and an optional dependency array.
* Internally uses `InteractionManager.runAfterInteractions()` to schedule the effect.
* Cancels the interaction if the component is unmounted or dependencies change.

#### 🧪 Example Usage

```tsx
useAfterInteractionsEffect(() => {
  // Heavy logic or API calls
}, [someDependency]);
```

#### 📈 Use Cases

* Delaying non-critical logic like analytics, API calls, or list rendering.
* Optimizing screen transitions by offloading heavy work until after animations settle.

#### 🧹 Cleanup

* The hook ensures cancellation of any scheduled interactions to avoid memory leaks or unexpected executions.
